### PR TITLE
FAQ and glossary deleted from projects.yml

### DIFF
--- a/menu_settings/projects.yml
+++ b/menu_settings/projects.yml
@@ -55,7 +55,5 @@
   description: Questions & Answers
   path: en/knowledge-base/
   pages:
-    Glossary: glossary/
-    FAQ: faq/
     Contribution manual: contributing/contribution-manual
 

--- a/menu_settings/toc.yml
+++ b/menu_settings/toc.yml
@@ -9,8 +9,6 @@
   - Research and development
   - Implementation
   - Knowledge base:
-    - Glossary
-    - FAQ
     - Contributing:
       - Contribution Manual
       - Markdown Styleguide


### PR DESCRIPTION
As there is no need for these links as they are leading to a dead end.